### PR TITLE
Add simple static server for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,22 @@ A single-page React app that deals a random vibe from the curated image collecti
 
 ## Local development
 
-No build step is required. Use any static file server or open `index.html` directly in your browser.
+The app fetches local files, so the browser must load it over HTTP.
+Opening `index.html` directly from the filesystem triggers CORS errors.
+Start the included static server:
 
 ```bash
-# from the repository root
+npm start
+```
+
+This launches at [http://localhost:3000](http://localhost:3000).
+You can use any other static server if you prefer, for example:
+
+```bash
 python -m http.server 8000
 ```
 
-Visit [http://localhost:8000](http://localhost:8000) in your browser.
+and visit [http://localhost:8000](http://localhost:8000) in your browser.
 
 ## Updating images
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vibedealer",
+  "private": true,
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,39 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.jsx': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif'
+};
+
+const server = http.createServer((req, res) => {
+  const safePath = path.normalize(decodeURI(req.url)).replace(/^\/+/,'');
+  let filePath = path.join(__dirname, safePath);
+  if (safePath === '' || safePath === '/') {
+    filePath = path.join(__dirname, 'index.html');
+  }
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(err.code === 'ENOENT' ? 404 : 500);
+      res.end(err.code === 'ENOENT' ? 'Not found' : 'Server error');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const type = mimeTypes[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(content, 'utf-8');
+    }
+  });
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- serve static files over HTTP with a lightweight Node server to avoid local CORS errors
- document new development workflow and add an `npm start` script

## Testing
- `npm test`
- `npm start` and `curl http://localhost:3000/app.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a7ef7f476c83319411c3ea727b8b97